### PR TITLE
Edge consolidation

### DIFF
--- a/src/admin.py
+++ b/src/admin.py
@@ -181,6 +181,9 @@ def refresh_metakg(reset=True, include_trapi=True):
     logging.info("Refreshing MetaKG index")
     SmartAPI.refresh_metakg(include_trapi=include_trapi)
 
+def consolidate_metakg():
+    logging.info("Consolidating MetaKG edges")
+    SmartAPI.index_metakg_consolidation()
 
 restore = restore_from_file
 backup = backup_to_file

--- a/src/admin.py
+++ b/src/admin.py
@@ -182,6 +182,10 @@ def refresh_metakg(reset=True, include_trapi=True):
     SmartAPI.refresh_metakg(include_trapi=include_trapi)
 
 def consolidate_metakg(reset=True):
+    """ Consolidate the MetaKG edge data into documents based on a subject-predicate-object key.
+        Creates an index with the groups.
+        *** Currently, must be run after running refresh_metakg() 
+    """
     if reset:
         logging.info("Reset ConsolidatedMetaKG index")
         indices.reset(ConsolidatedMetaKGDoc)

--- a/src/admin.py
+++ b/src/admin.py
@@ -30,7 +30,7 @@ import boto3
 from filelock import FileLock, Timeout
 
 from controller import SmartAPI
-from model import MetaKGDoc, ConsolidatedMetaKGDoc
+from model import ConsolidatedMetaKGDoc, MetaKGDoc
 from utils import indices
 
 logging.basicConfig(level="INFO")
@@ -181,10 +181,11 @@ def refresh_metakg(reset=True, include_trapi=True):
     logging.info("Refreshing MetaKG index")
     SmartAPI.refresh_metakg(include_trapi=include_trapi)
 
+
 def consolidate_metakg(reset=True):
-    """ Consolidate the MetaKG edge data into documents based on a subject-predicate-object key.
-        Creates an index with the groups.
-        *** Currently, must be run after running refresh_metakg() 
+    """Consolidate the MetaKG edge data into documents based on a subject-predicate-object key.
+    Creates an index with the groups.
+    *** Currently, must be run after running refresh_metakg()
     """
     if reset:
         logging.info("Reset ConsolidatedMetaKG index")
@@ -192,6 +193,7 @@ def consolidate_metakg(reset=True):
 
     logging.info("Consolidating/Refreshing MetaKG edges")
     SmartAPI.index_metakg_consolidation()
+
 
 restore = restore_from_file
 backup = backup_to_file

--- a/src/admin.py
+++ b/src/admin.py
@@ -30,7 +30,7 @@ import boto3
 from filelock import FileLock, Timeout
 
 from controller import SmartAPI
-from model import MetaKGDoc
+from model import MetaKGDoc, ConsolidatedMetaKGDoc
 from utils import indices
 
 logging.basicConfig(level="INFO")
@@ -181,8 +181,12 @@ def refresh_metakg(reset=True, include_trapi=True):
     logging.info("Refreshing MetaKG index")
     SmartAPI.refresh_metakg(include_trapi=include_trapi)
 
-def consolidate_metakg():
-    logging.info("Consolidating MetaKG edges")
+def consolidate_metakg(reset=True):
+    if reset:
+        logging.info("Reset ConsolidatedMetaKG index")
+        indices.reset(ConsolidatedMetaKGDoc)
+
+    logging.info("Consolidating/Refreshing MetaKG edges")
     SmartAPI.index_metakg_consolidation()
 
 restore = restore_from_file

--- a/src/config.py
+++ b/src/config.py
@@ -64,9 +64,11 @@ ANNOTATION_KWARGS["GET"]["_sorted"]["default"] = False
 ES_HOST = "localhost:9200"
 SMARTAPI_ES_INDEX = "smartapi_docs"
 METAKG_ES_INDEX = "smartapi_metakg_docs"
+METAKG_ES_INDEX_CONSOLIDATED = "smartapi_metakg_docs_consolidated"
 ES_INDICES = {
     "metadata": SMARTAPI_ES_INDEX,
     "metakg": METAKG_ES_INDEX,
+    "metakg_consolidated": METAKG_ES_INDEX_CONSOLIDATED
 }
 
 # *****************************************************************************
@@ -84,6 +86,8 @@ APP_LIST = [
     (r"/api/suggestion/?", "handlers.api.ValueSuggestionHandler"),
     (r"/api/metakg/?", "handlers.api.MetaKGQueryHandler", {"biothing_type": "metakg"}),
     (r"/api/metakg/fields/?", "biothings.web.handlers.MetadataFieldHandler", {"biothing_type": "metakg"}),
+    (r"/api/metakg/consolidated/?", "handlers.api.MetaKGQueryHandler", {"biothing_type": "metakg_consolidated"})
+
 ]
 
 # biothings web tester will read this

--- a/src/config.py
+++ b/src/config.py
@@ -68,7 +68,7 @@ METAKG_ES_INDEX_CONSOLIDATED = "smartapi_metakg_docs_consolidated"
 ES_INDICES = {
     "metadata": SMARTAPI_ES_INDEX,
     "metakg": METAKG_ES_INDEX,
-    "metakg_consolidated": METAKG_ES_INDEX_CONSOLIDATED
+    "metakg_consolidated": METAKG_ES_INDEX_CONSOLIDATED,
 }
 
 # *****************************************************************************
@@ -86,8 +86,7 @@ APP_LIST = [
     (r"/api/suggestion/?", "handlers.api.ValueSuggestionHandler"),
     (r"/api/metakg/?", "handlers.api.MetaKGQueryHandler", {"biothing_type": "metakg"}),
     (r"/api/metakg/fields/?", "biothings.web.handlers.MetadataFieldHandler", {"biothing_type": "metakg"}),
-    (r"/api/metakg/consolidated/?", "handlers.api.MetaKGQueryHandler", {"biothing_type": "metakg_consolidated"})
-
+    (r"/api/metakg/consolidated/?", "handlers.api.MetaKGQueryHandler", {"biothing_type": "metakg_consolidated"}),
 ]
 
 # biothings web tester will read this

--- a/src/controller/base.py
+++ b/src/controller/base.py
@@ -194,10 +194,10 @@ class AbstractWebEntity(ABC):
 
     @classmethod
     def get_all_via_scan(cls, size=1000, query_data=None, index=None, scroll="1m"):
-        """ Uses elasticsearch_dsl to traverse through the MetaKG index.
-            Elasticsearch has a size window limit of 10,000.
-            Using scan allows us to scroll through the data, and retrieve all index data hits.
-            If no index name is passed, will set index to the default cls index name, `smartapi_docs`
+        """Uses elasticsearch_dsl to traverse through the MetaKG index.
+        Elasticsearch has a size window limit of 10,000.
+        Using scan allows us to scroll through the data, and retrieve all index data hits.
+        If no index name is passed, will set index to the default cls index name, `smartapi_docs`
         """
         from elasticsearch.helpers import scan
         from elasticsearch_dsl import connections

--- a/src/controller/base.py
+++ b/src/controller/base.py
@@ -193,6 +193,27 @@ class AbstractWebEntity(ABC):
                 yield doc
 
     @classmethod
+    def get_all_via_scan(cls, size=1000, query_data=None, index=None, scroll="1m"):
+        """ Uses elasticsearch_dsl to traverse through the MetaKG index.
+            Elasticsearch has a size window limit of 10,000.
+            Using scan allows us to scroll through the data, and retrieve all index data hits.
+            If no index name is passed, will set index to the default cls index name, `smartapi_docs`
+        """
+        from elasticsearch.helpers import scan
+        from elasticsearch_dsl import connections
+
+        es = connections.get_connection()
+
+        if not index:
+            index = cls.MODEL_CLASS.Index.name
+
+        # Make the initial scan request
+        response = scan(es, query=query_data, index=index, size=size, scroll=scroll)
+
+        for hit in response:
+            yield hit
+
+    @classmethod
     def get(cls, _id):
         try:
             doc = cls.MODEL_CLASS.get(_id)

--- a/src/handlers/api.py
+++ b/src/handlers/api.py
@@ -390,7 +390,7 @@ class MetaKGQueryHandler(QueryHandler):
                 "type": str,
                 "default": "json",
                 "enum": ("json", "yaml", "html", "msgpack", "graphml"),
-            }
+            },
         },
         "GET": {
             **QUERY_KWARGS.get("GET", {}),

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -1,5 +1,4 @@
-from .metakg import MetaKGDoc
+from .metakg import ConsolidatedMetaKGDoc, MetaKGDoc
 from .smartapi import SmartAPIDoc
-from .metakg import ConsolidatedMetaKGDoc
 
 __all__ = [MetaKGDoc, SmartAPIDoc, ConsolidatedMetaKGDoc]

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -1,4 +1,5 @@
 from .metakg import MetaKGDoc
 from .smartapi import SmartAPIDoc
+from .metakg import ConsolidatedMetaKGDoc
 
-__all__ = [MetaKGDoc, SmartAPIDoc]
+__all__ = [MetaKGDoc, SmartAPIDoc, ConsolidatedMetaKGDoc]

--- a/src/model/metakg.py
+++ b/src/model/metakg.py
@@ -1,7 +1,7 @@
 """
     Elasticsearch Document Object Model for MetaKG
 """
-from elasticsearch_dsl import InnerDoc, Keyword, Nested, Object, Text, analysis, mapping
+from elasticsearch_dsl import InnerDoc, Keyword, Object, Text, analysis, mapping
 
 from config import METAKG_ES_INDEX, METAKG_ES_INDEX_CONSOLIDATED
 

--- a/src/model/metakg.py
+++ b/src/model/metakg.py
@@ -1,9 +1,9 @@
 """
     Elasticsearch Document Object Model for MetaKG
 """
-from elasticsearch_dsl import InnerDoc, Keyword, Object, Text, analysis, mapping, Nested
+from elasticsearch_dsl import InnerDoc, Keyword, Nested, Object, Text, analysis, mapping
 
-from config import METAKG_ES_INDEX , METAKG_ES_INDEX_CONSOLIDATED
+from config import METAKG_ES_INDEX, METAKG_ES_INDEX_CONSOLIDATED
 
 from .base import BaseDoc
 
@@ -13,8 +13,11 @@ lowercase_keyword_copy_to_all = Keyword(
     normalizer=analysis.normalizer("lowercase_normalizer", filter=["lowercase"]), copy_to="all"
 )
 lowercase_keyword_node = Keyword(
-    normalizer=analysis.normalizer("lowercase_normalizer", filter=["lowercase"]), copy_to=["all", "node"],
-    fields={"raw": Keyword()}    # include subject.raw and object.raw fields as the original values for aggregation purpose
+    normalizer=analysis.normalizer("lowercase_normalizer", filter=["lowercase"]),
+    copy_to=["all", "node"],
+    fields={
+        "raw": Keyword()
+    },  # include subject.raw and object.raw fields as the original values for aggregation purpose
 )
 default_text = Text(fields={"raw": lowercase_keyword}, copy_to="all")
 metakg_mapping = mapping.Mapping()
@@ -93,8 +96,10 @@ class APIInnerDoc(InnerDoc):
     # We cannot define "x-translator" field here due the "-" in the name,
     # so we will have it indexed via the dynamic templates
 
+
 class ConsolidatedAPIInnerDoc(APIInnerDoc):
     provided_by = default_text
+
 
 class MetaKGDoc(BaseDoc):
     subject = lowercase_keyword_node
@@ -122,10 +127,12 @@ class MetaKGDoc(BaseDoc):
     def get_url(self):
         return self.api.smartapi.metadata
 
+
 class ConsolidatedMetaKGDoc(BaseDoc):
-    """ MetaKG ES index for edges consolidated on their subject/predicate/object
-        Multiple APIs providing the same edge, grouped as a list under the 'api' field.
+    """MetaKG ES index for edges consolidated on their subject/predicate/object
+    Multiple APIs providing the same edge, grouped as a list under the 'api' field.
     """
+
     # Existing fields
     subject = lowercase_keyword_node
     object = lowercase_keyword_node


### PR DESCRIPTION
Adds method, `consolidate_metakg()`, available for import from `admin.py`.  This method scans the `smartapi_metakg_docs` index and consolidates the edges into grouped documents matched on the `subject-predicate-object`, and creates a new metakg index, `smartapi_metakg_docs_consolidated`.  

Method, `get_all_via_scan()`, to `controller.base` , that scans an ES index and yields the hits back. This allows us to get back all the data hits in an index, getting around the size limit of pagination and the ES window size, 10,000. *See method for further details*.

