### PR TITLE
removed bte & provided_by fields from index and modified for duplicates

### DIFF
--- a/src/controller/smartapi.py
+++ b/src/controller/smartapi.py
@@ -190,15 +190,10 @@ class SmartAPI(AbstractWebEntity, Mapping):
 
             # get the edge api to modify
             edge_api = edge["_source"]["api"]
-            # add bte & provided_by fields to the edge
-            if "bte" in edge["_source"]:
-                edge_api["bte"] = edge["_source"]["bte"]
-            if "provided_by" in edge["_source"]:
-                edge_api["provided_by"] = edge["_source"]["provided_by"]
-
             # add edge to the correct group(based on key)
             if key in edge_dict:
-                edge_dict[key]["api"].append(edge_api)
+                if edge_api not in edge_dict[key]["api"]:
+                    edge_dict[key]["api"].append(edge_api)
             else:
                 edge_dict[key] = {
                     "_id": key,


### PR DESCRIPTION
Quick edit to remove the duplicate `api` dictionaries. These duplicate apis differed slightly in their `provided_by` and `bte` fields. For the purpose of this, we omitted those fields from the metakg consolidated index and removed all duplicated apis, maintaining a single reference. 