### PR TITLE
Added a metakg flag issue#218

### DIFF
--- a/src/admin.py
+++ b/src/admin.py
@@ -195,6 +195,26 @@ def consolidate_metakg(reset=True):
     SmartAPI.index_metakg_consolidation()
 
 
+def refresh_has_metakg():
+    """
+    Refreshes the 'has_metakg' attribute for SmartAPI objects.
+    This function iterates through all SmartAPI objects, checks if there's a corresponding entry in the ConsolidatedMetaKGDoc 
+    collection based on the SmartAPI ID, and updates the 'has_metakg' attribute accordingly.
+    Note:
+    - This function assumes the existence of the SmartAPI and ConsolidatedMetaKGDoc classes.
+    - 'has_metakg' attribute is a boolean value indicating whether a SmartAPI has corresponding metadata in the Meta-Knowledge Graph.
+    Returns:
+    None
+    """
+    for smartapi in SmartAPI.get_all(1000):
+        value = ConsolidatedMetaKGDoc.exists(smartapi._id, field="api.smartapi.id")
+        if value:
+            smartapi.has_metakg = True
+        else:
+            smartapi.has_metakg = False
+        smartapi.save()
+
+
 restore = restore_from_file
 backup = backup_to_file
 
@@ -229,6 +249,8 @@ def routine():
     refresh_metakg()
     logger.info("consolidate_metakg()")
     consolidate_metakg()
+    logger.info("refresh_has_metakg()")
+    refresh_has_metakg()
 
 
 if __name__ == "__main__":

--- a/src/controller/smartapi.py
+++ b/src/controller/smartapi.py
@@ -100,6 +100,7 @@ class SmartAPI(AbstractWebEntity, Mapping):
         self.slug = None
         self.date_created = None
         self.last_updated = None
+        self.has_metakgq = None
 
         self.uptime = APIMonitorStatus(self)
         self.webdoc = APIRefreshStatus(self)
@@ -116,6 +117,8 @@ class SmartAPI(AbstractWebEntity, Mapping):
 
         obj.date_created = obj._doc._meta.date_created
         obj.last_updated = obj._doc._meta.last_updated
+
+        obj.has_metakg = obj._doc._meta.has_metakg
 
         obj.uptime = APIMonitorStatus(
             obj,
@@ -289,6 +292,14 @@ class SmartAPI(AbstractWebEntity, Mapping):
         if self.date_created > self.last_updated:
             raise ControllerError("Invalid timestamps.")
 
+
+        if not self.has_metakg:
+            value = ConsolidatedMetaKGDoc.exists(self._id, field="api.smartapi.id")
+            if value:
+                self.has_metakg = True
+            else:
+                self.has_metakg = False
+
         # NOTE
         # if the slug of another document changed at this point
         # it's possible to have two documents with the same slug
@@ -326,7 +337,7 @@ class SmartAPI(AbstractWebEntity, Mapping):
         doc._meta.date_created = self.date_created
         doc._meta.last_updated = self.last_updated
         doc._meta.slug = self.slug
-
+        doc._meta.has_metakg = self.has_metakg
         doc.save(skip_empty=False)
 
         return self._id

--- a/src/model/smartapi.py
+++ b/src/model/smartapi.py
@@ -1,7 +1,7 @@
 """
     Elasticsearch Document Object Model for SmartAPI
 """
-from elasticsearch_dsl import Binary, Date, InnerDoc, Integer, Keyword, Object, Text
+from elasticsearch_dsl import Binary, Date, InnerDoc, Integer, Keyword, Object, Text, Boolean
 
 from config import SMARTAPI_ES_INDEX
 
@@ -27,7 +27,7 @@ class UserMeta(InnerDoc):
     username = Keyword(required=True)
     date_created = Date(default_timezone="UTC")
     last_updated = Date(default_timezone="UTC")
-
+    has_metakg = Boolean()
 
 class SmartAPIDoc(BaseDoc):
     _status = Object(StatMeta)


### PR DESCRIPTION
Added flag, `has_metakg` , under `_meta` , that will label `true` if the api is included in the metakg index, else `false`.
This is a standalone function run with, `refresh_has_metakg()`, and is the final function that runs in the daily routine. 
Addresses issue [218](https://github.com/SmartAPI/smartAPI/issues/218).