### PR TITLE
Pathfinder feature upgrade-expand and predicate filter

### DIFF
--- a/src/utils/metakg/biolink_helpers.py
+++ b/src/utils/metakg/biolink_helpers.py
@@ -1,0 +1,20 @@
+from typing import Union, List
+import bmt
+
+# Initialize the Biolink Model Toolkit instance globally if it's used frequently
+# or pass it as a parameter to functions that require it.
+toolkit = bmt.Toolkit()
+
+def get_expanded_values(value: Union[str, List[str]], toolkit_instance=toolkit) -> List[str]:
+    """Return expanded value list for a given Biolink class name."""
+    if isinstance(value, str):
+        value = [value]
+    _out = []
+    for v in value:
+        try:
+            v = toolkit_instance.get_descendants(v, reflexive=True, formatted=True)
+            v = [x.split(":")[-1] for x in v]  # Remove 'biolink:' prefix
+        except ValueError:
+            v = [v]
+        _out.extend(v)
+    return _out

--- a/src/utils/metakg/path_finder.py
+++ b/src/utils/metakg/path_finder.py
@@ -96,6 +96,7 @@ class MetaKGPathFinder:
         - expanded_fields: (dict) The expanded fields containing lists of subjects and objects.
         - cutoff: (int, default=3) The maximum length for any path returned.
         - api_details: (bool, default=False) If True, includes full details of the 'api' in the result.
+        - predicate_filter: (list, default=None) A list of predicates to filter the results by.
 
         Returns:
         - all_paths_with_edges: (list of dict) A list containing paths and their edge information for all subject-object pairs.


### PR DESCRIPTION
**Key Upgrades:**

- Added  `&expand`  to expand path searching on subject/object/predicate parameters.  
- Added `&predicate` to filter path results based on a given predicate.
- Added a `&rawquery` output for `/paths` search.
  
Example endpoints: 
Rawquery & subject expand: `api/metakg/paths?q=api.name:BTE&subject=Virus&object=Disease&cutoff=2&expand=subject&rawquery=1`  
Predicate filter: `/api/metakg/paths?subject=BiologicalProcessOrActivity&object=ClinicalFinding&cutoff=2&predicate=derives_into&expand=predicate&rawquery=0`. 
Predicate expand: `/api/metakg/paths?subject=BiologicalProcessOrActivity&object=ClinicalFinding&cutoff=2&predicate=derives_into&expand=predicate&rawquery=0`