### PR TITLE
Override AsyncBackend for metakg index

### DIFF
--- a/src/handlers/api.py
+++ b/src/handlers/api.py
@@ -424,7 +424,8 @@ class MetaKGQueryHandler(QueryHandler):
             "header": {
                 "type": bool,
                 "default": True
-            }
+            },
+            "consolidated": {"type": bool, "default": True}
         },
     }
 


### PR DESCRIPTION
Extends the AsyncBackend to allow ES index choice for metakg. 
Use `&consolidated=1` (default) to query the `metakg_consolidated` index, and `&consolidated=0` to query the original `metakg` index. 
- removes the `/api/metakg/consolidated?` endpoint, and replaces with: `/api/metakg/?q=*&consolidated=0` or `/api/metakg/?q=*&consolidated=1`