### PR TITLE
Downgrade pycurl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ biothings[web_extra]==0.12.5
 jsonschema>=4.4.0
 
 # web handling
-pycurl==7.45.3       # to use curl_httpclient in tornado
+pycurl==7.45.2       # to use curl_httpclient in tornado
 #chardet==3.0.4
 aiocron==1.8
 


### PR DESCRIPTION
We were getting this error:
```
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]: ERROR:tornado.application:Uncaught exception GET /oauth?next=/&code=d83014ddc29a28177a35 (76.33.16.144)
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]: HTTPServerRequest(protocol='https', host='dev.smart-api.info', method='GET', uri='/oauth?next=/&code=d83014ddc29a28177a35', version='HTTP/1.0', remote_>
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]: Traceback (most recent call last):
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]:   File "/home/ubuntu/smartapi/.env/lib/python3.10/site-packages/tornado/web.py", line 1790, in _execute
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]:     result = await result
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]:   File "/home/ubuntu/smartapi/src/handlers/oauth.py", line 32, in get
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]:     token = await self.github_get_oauth2_token(client_id=CLIENT_ID, client_secret=CLIENT_SECRET, code=code)
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]:   File "/home/ubuntu/smartapi/.env/lib/python3.10/site-packages/biothings/web/auth/oauth_mixins.py", line 56, in github_get_oauth2_token
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]:     response = await http.fetch(
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]: tornado.curl_httpclient.CurlError: HTTP 599: error setting certificate verify locations:
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]:   CAfile: /etc/pki/tls/certs/ca-bundle.crt
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]:   CApath: none
Sep 19 10:10:06 ip-172-40-40-242 python[1878404]: ERROR:tornado.access:500 GET /oauth?next=/&code=d83014ddc29a28177a35 (76.33.16.144) 9.98ms
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]: INFO:root:got code, try to get token
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]: ERROR:tornado.application:Uncaught exception GET /oauth?next=/&code=c2b219850f656532c729 (68.7.213.7)
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]: HTTPServerRequest(protocol='https', host='dev.smart-api.info', method='GET', uri='/oauth?next=/&code=c2b219850f656532c729', version='HTTP/1.0', remote_>
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]: Traceback (most recent call last):
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]:   File "/home/ubuntu/smartapi/.env/lib/python3.10/site-packages/tornado/web.py", line 1790, in _execute
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]:     result = await result
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]:   File "/home/ubuntu/smartapi/src/handlers/oauth.py", line 32, in get
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]:     token = await self.github_get_oauth2_token(client_id=CLIENT_ID, client_secret=CLIENT_SECRET, code=code)
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]:   File "/home/ubuntu/smartapi/.env/lib/python3.10/site-packages/biothings/web/auth/oauth_mixins.py", line 56, in github_get_oauth2_token
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]:     response = await http.fetch(
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]: tornado.curl_httpclient.CurlError: HTTP 599: error setting certificate verify locations:
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]:   CAfile: /etc/pki/tls/certs/ca-bundle.crt
Sep 19 10:10:52 ip-172-40-40-242 python[1878396]:   CApath: none
```

This works but it's going to be deprecated as we can see below
```
pip install --no-binary pycurl pycurl==7.45.3

DEPRECATION: --no-binary currently disables reading from the cache of locally built wheels.
In the future --no-binary will not influence the wheel cache. pip 23.1 will enforce this behaviour change. 
A possible replacement is to use the --no-cache-dir option. 
You can use the flag --use-feature=no-binary-enable-wheel-cache to test the upcoming behaviour. 
Discussion can be found at https://github.com/pypa/pip/issues/11453
```

The suggestion didn't work
```
pip install --no-cache-dir pycurl==7.45.3
```

So we decided to downgrade to 7.45.2 for now.




