### PR TITLE
Add New Endpoint: /metakg/parse ISSUE#271

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -96,6 +96,7 @@ APP_LIST = [
     (r"/api/metakg/consolidated/?", "handlers.api.MetaKGQueryHandler", {"biothing_type": "metakg_consolidated"}),
     (r"/api/metakg/consolidated/fields/?", "biothings.web.handlers.MetadataFieldHandler", {"biothing_type": "metakg_consolidated"}),
     (r"/api/metakg/paths/?", "handlers.api.MetaKGPathFinderHandler", {"biothing_type": "metakgpathfinder"}),
+    (r"/api/metakg/parse/?", "handlers.api.MetaKGParserHandler"),
 ]
 
 # biothings web tester will read this

--- a/src/controller/smartapi.py
+++ b/src/controller/smartapi.py
@@ -369,24 +369,10 @@ class SmartAPI(AbstractWebEntity, Mapping):
         """return True if a TRAPI"""
         return self.has_tags("trapi", "translator")
 
-    # def get_metakg(self, include_trapi=True):
-    #     raw_metadata = decoder.to_dict(decoder.decompress(self._doc._raw))
-    #     mkg_parser = MetaKGParser()
-    #     extra_data = {"id": self._id, "url": self.url}
-    #     self.metakg_errors = None  # reset metakg_errors
-    #     if self.is_trapi:
-    #         metakg = mkg_parser.get_TRAPI_metadatas(raw_metadata, extra_data) if include_trapi else []
-    #     else:
-    #         metakg = mkg_parser.get_non_TRAPI_metadatas(raw_metadata, extra_data)
-    #     if mkg_parser.metakg_errors:
-    #         # hold metakg_errors for later use
-    #         self.metakg_errors = mkg_parser.metakg_errors
-    #     return metakg
-
     def get_metakg(self, include_trapi=True, metadata_url=False):
         if metadata_url:
-            data_id = decoder.get_id(self.url) # get ID
-            doc = self.get(data_id)# get smartapi data
+            data_id = decoder.get_id(self.url)
+            doc = self.get(data_id)
             self._doc = doc._doc
             raw_metadata = decoder.to_dict(decoder.decompress(doc._doc._raw))
         else:

--- a/src/controller/smartapi.py
+++ b/src/controller/smartapi.py
@@ -369,8 +369,28 @@ class SmartAPI(AbstractWebEntity, Mapping):
         """return True if a TRAPI"""
         return self.has_tags("trapi", "translator")
 
-    def get_metakg(self, include_trapi=True):
-        raw_metadata = decoder.to_dict(decoder.decompress(self._doc._raw))
+    # def get_metakg(self, include_trapi=True):
+    #     raw_metadata = decoder.to_dict(decoder.decompress(self._doc._raw))
+    #     mkg_parser = MetaKGParser()
+    #     extra_data = {"id": self._id, "url": self.url}
+    #     self.metakg_errors = None  # reset metakg_errors
+    #     if self.is_trapi:
+    #         metakg = mkg_parser.get_TRAPI_metadatas(raw_metadata, extra_data) if include_trapi else []
+    #     else:
+    #         metakg = mkg_parser.get_non_TRAPI_metadatas(raw_metadata, extra_data)
+    #     if mkg_parser.metakg_errors:
+    #         # hold metakg_errors for later use
+    #         self.metakg_errors = mkg_parser.metakg_errors
+    #     return metakg
+
+    def get_metakg(self, include_trapi=True, metadata_url=False):
+        if metadata_url:
+            data_id = decoder.get_id(self.url) # get ID
+            doc = self.get(data_id)# get smartapi data
+            self._doc = doc._doc
+            raw_metadata = decoder.to_dict(decoder.decompress(doc._doc._raw))
+        else:
+            raw_metadata = decoder.to_dict(decoder.decompress(self._doc._raw))
         mkg_parser = MetaKGParser()
         extra_data = {"id": self._id, "url": self.url}
         self.metakg_errors = None  # reset metakg_errors

--- a/src/handlers/api.py
+++ b/src/handlers/api.py
@@ -686,3 +686,32 @@ class MetaKGPathFinderHandler(QueryHandler):
             }
         await asyncio.sleep(0.01)
         self.finish(res)
+
+class MetaKGParserHandler(QueryHandler):
+    name="metakgparser"
+    kwargs = {
+        "GET": {
+            "url": {
+                "type": str,
+                "required": True, 
+                "max": 1000,
+                "description": "URL of the SmartAPI metadata to parse"
+            },
+        },
+        "POST": {
+            "type": dict,
+            "required": True,
+            "description": "Metadata content of the SmartAPI in JSON format"
+            },
+    }
+    
+
+    async def get(self, *args, **kwargs):
+        if self.request.method == "GET":
+            smartapi = SmartAPI(self.args.url)
+            content=smartapi.get_metakg(metadata_url=self.args.url)
+            self.finish(f"{content}")
+        elif self.request.method == "POST":
+            print(f"\n\n[INFO] HERE")
+            # pass
+            self.finish(f"HERE")

--- a/src/handlers/api.py
+++ b/src/handlers/api.py
@@ -821,7 +821,7 @@ class MetaKGParserHandler(BaseHandler):
             }
 
             self.set_header("Content-Type", "application/json")
-            self.write(json.dumps(response)
+            self.write(json.dumps(response))
 
         except json.JSONDecodeError:
             self.set_status(400)

--- a/src/tests/_utils/metakg/integration/parser/parse.py
+++ b/src/tests/_utils/metakg/integration/parser/parse.py
@@ -1,0 +1,80 @@
+import unittest
+import requests
+import json
+
+
+class TestAPI(unittest.TestCase):
+    URL_EXAMPLE = "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/mygene.info/openapi_full.yml"
+
+    def setUp(self):
+        self.headers = {"Content-Type": "application/json"}
+        with open('/Users/nacosta/Documents/smartAPI/WORKING_BRANCH/add-metakg-endpoint/smartAPI/src/metadata_content.json', 'r') as file:
+            self.data = json.load(file)
+
+    # POST Tests
+    def test_post_metakg_parse_api_details_1_bte_1(self):
+        url = "http://localhost:8000/api/metakg/parse?api_details=1&bte=1"
+        response = requests.post(url, headers=self.headers, json=self.data)
+        json_response = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('api', json_response['hits'][0].keys())
+        self.assertIn('bte', json_response['hits'][0].keys())
+
+    def test_post_metakg_parse_api_details_0_bte_1(self):
+        url = "http://localhost:8000/api/metakg/parse?api_details=0&bte=1"
+        response = requests.post(url, headers=self.headers, json=self.data)
+        json_response = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('bte', json_response['hits'][0].keys())
+
+    def test_post_metakg_parse_api_details_1_bte_0(self):
+        url = "http://localhost:8000/api/metakg/parse?api_details=1&bte=0"
+        response = requests.post(url, headers=self.headers, json=self.data)
+        json_response = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('api', json_response['hits'][0].keys())
+        self.assertNotIn('bte', json_response['hits'][0].keys())
+
+    def test_post_metakg_parse_api_details_0_bte_0(self):
+        url = "http://localhost:8000/api/metakg/parse?api_details=0&bte=0"
+        response = requests.post(url, headers=self.headers, json=self.data)
+        json_response = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('bte', json_response['hits'][0].keys())
+        self.assertIn('subject', json_response['hits'][0].keys())
+
+    # GET Tests
+    def test_get_metakg_parse_api_details_1_bte_1(self):
+        url = f"http://localhost:8000/api/metakg/parse?url={self.URL_EXAMPLE}&api_details=1&bte=1"
+        response = requests.get(url)
+        json_response = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('api', json_response['hits'][0].keys())
+        self.assertIn('bte', json_response['hits'][0].keys())
+
+    def test_get_metakg_parse_api_details_0_bte_1(self):
+        url = f"http://localhost:8000/api/metakg/parse?url={self.URL_EXAMPLE}&api_details=0&bte=1"
+        response = requests.get(url)
+        json_response = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('bte', json_response['hits'][0].keys())
+
+    def test_get_metakg_parse_api_details_1_bte_0(self):
+        url = f"http://localhost:8000/api/metakg/parse?url={self.URL_EXAMPLE}&api_details=1&bte=0"
+        response = requests.get(url)
+        json_response = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('api', json_response['hits'][0].keys())
+        self.assertNotIn('bte', json_response['hits'][0].keys())
+
+    def test_get_metakg_parse_api_details_0_bte_0(self):
+        url = f"http://localhost:8000/api/metakg/parse?url={self.URL_EXAMPLE}&api_details=0&bte=0"
+        response = requests.get(url)
+        json_response = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('bte', json_response['hits'][0].keys())
+        self.assertIn('subject', json_response['hits'][0].keys())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/utils/metakg/parser.py
+++ b/src/utils/metakg/parser.py
@@ -13,17 +13,28 @@ class MetaKGParser:
     get_url_timeout = 60
     metakg_errors = None
 
-    def get_non_TRAPI_metadatas(self, data, extra_data=None):
-        parser = API(data)
+    def get_non_TRAPI_metadatas(self, data=None, extra_data=None, url=None): # *** TEST THIS FOR BREAK POINTS ***
+        if data:
+            parser = API(smartapi_doc=data)
+        elif url:
+            parser = API(url=url)
+        else: 
+            return [] # **** ERROR HANDLE THIS ****
         mkg = self.extract_metakgedges(parser.metadata["operations"], extra_data=extra_data)
         no_nodes = len({x["subject"] for x in mkg} | {x["object"] for x in mkg})
         no_edges = len({x["predicate"] for x in mkg})
         logger.info("Done [%s nodes, %s edges]", no_nodes, no_edges)
         return mkg
 
-    def get_TRAPI_metadatas(self, data, extra_data=None):
+    def get_TRAPI_metadatas(self, data=None, extra_data=None, url=None):
         ops = []
-        metadata_list = self.get_TRAPI_with_metakg_endpoint(data)
+        if data:
+            metadata_list = self.get_TRAPI_with_metakg_endpoint(data=data)
+        elif url:
+            metadata_list = self.get_TRAPI_with_metakg_endpoint(url=url)
+        else:
+            return [] # **** ERROR HANDLE THIS ****
+
         count_metadata_list = len(metadata_list)
         self.metakg_errors = {}
         for i, metadata in enumerate(metadata_list):
@@ -34,7 +45,13 @@ class MetaKGParser:
 
         return self.extract_metakgedges(ops, extra_data=extra_data)
 
-    def get_TRAPI_with_metakg_endpoint(self, data):
+    def get_TRAPI_with_metakg_endpoint(self, data=None, url=None): # TEST THIS FOR BREAK POINTS
+        # Use the URL if provided, otherwise fall back to the 'data' argument
+        if data:
+            parser = API(data)
+        elif url:
+            parser = API(url=url)
+
         metadatas = []
         parser = API(data)
         metadata = parser.metadata


### PR DESCRIPTION
New endpoint (`/api/metakg/parse`) added that enables direct access to the internal MetaKG parser for processing individual API metadata. This feature supports both `GET` and `POST` methods:

- **GET**:  
  - Endpoint: `GET /api/metakg/parse?url=<api_metadata_url>` 
  - Example: `../api/metakg/parse?url=https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/mygene.info/openapi_full.yml`
  - Takes a `url` query parameter pointing to the API metadata content to be parsed.

- **POST**:  
  - Endpoint: `POST /api/metakg/parse`
  - Example: (using curl) `curl -X POST ../api/metakg/parse -H "Content-Type: application/json" -d @metadata_content.json`   
  - Expects the raw API metadata content in the request body.

Available flags: 
- `&api_details=1` : gives full api info. 
- `&bte=1` : gives bte info.  



### **Output**  
The response will be a list of parsed MetaKG edges, formatted similarly to the existing `/api/metakg` endpoint.