### PR TITLE
fix: cast url as str

### DIFF
--- a/src/utils/monitor.py
+++ b/src/utils/monitor.py
@@ -295,7 +295,7 @@ class Endpoint:
                 if "example" in _param:
                     # parameter in path
                     if _param["in"] == "path":
-                        url = url.replace("{" + _param["name"] + "}", str(_param["example"]))
+                        url = str(url).replace("{" + _param["name"] + "}", str(_param["example"]))
                     # parameter in query
                     elif _param["in"] == "query":
                         params[_param["name"]] = _param["example"]


### PR DESCRIPTION
small fix to uptime monitor when metadata examples are provided as a number because they are made up of integers but in the end should be a string