### PR TITLE
Fix login issue

### DIFF
--- a/src/handlers/api.py
+++ b/src/handlers/api.py
@@ -48,21 +48,14 @@ class BaseHandler(BioThingsAuthnMixin, BaseAPIHandler):
 
 class AuthHandler(BaseHandler):
     def set_cache_header(self, cache_value):
-        # disabel cache for auth-related handlers
+        # disable cache for auth-related handlers
         self.set_header("Cache-Control", "private, max-age=0, no-cache")
-
-    def prepare(self):
-        """Override prepare to bypass parameter validation issues"""
-        # codacy:disable
-        super(BaseAPIHandler, self).prepare()
 
 
 class UserInfoHandler(AuthHandler):
-    """ "Handler for /user_info endpoint."""
-
-    # Define that no parameters are required for this endpoint
+    """ "Handler for /user endpoint."""
+    name = "user_info"
     kwargs = {
-        "*": {},  # Override any inherited parameter requirements
         "GET": {}  # Explicitly empty - no parameters expected or required
     }
 
@@ -84,9 +77,9 @@ class UserInfoHandler(AuthHandler):
 
 
 class LoginHandler(AuthHandler):
-    # Define expected parameters for login redirect
+    """ "Handler for /login endpoint."""
+    name = "user_login"
     kwargs = {
-        "*": {},  # Override any inherited parameter requirements
         "GET": {
             "next": {"type": str, "required": False, "default": "/"}  # Redirect URL
         }
@@ -97,9 +90,9 @@ class LoginHandler(AuthHandler):
 
 
 class LogoutHandler(AuthHandler):
-    # Define expected parameters for logout redirect
+    """ "Handler for /logout endpoint."""
+    name = "user_logout"
     kwargs = {
-        "*": {},  # Override any inherited parameter requirements
         "GET": {
             "next": {"type": str, "required": False, "default": "/"}  # Redirect URL
         }

--- a/src/handlers/api.py
+++ b/src/handlers/api.py
@@ -51,6 +51,11 @@ class AuthHandler(BaseHandler):
         # disabel cache for auth-related handlers
         self.set_header("Cache-Control", "private, max-age=0, no-cache")
 
+    def prepare(self):
+        """Override prepare to bypass parameter validation issues"""
+        # codacy:disable
+        super(BaseAPIHandler, self).prepare()
+
 
 class UserInfoHandler(AuthHandler):
     """ "Handler for /user_info endpoint."""
@@ -60,10 +65,6 @@ class UserInfoHandler(AuthHandler):
         "*": {},  # Override any inherited parameter requirements
         "GET": {}  # Explicitly empty - no parameters expected or required
     }
-
-    def prepare(self):
-        """Override prepare to bypass parameter validation issues"""
-        super(BaseAPIHandler, self).prepare()
 
     def get(self):
         # Check for user cookie
@@ -91,10 +92,6 @@ class LoginHandler(AuthHandler):
         }
     }
 
-    def prepare(self):
-        """Override prepare to bypass parameter validation issues"""
-        super(BaseAPIHandler, self).prepare()
-
     def get(self):
         self.redirect(self.get_argument("next", "/"))
 
@@ -107,10 +104,6 @@ class LogoutHandler(AuthHandler):
             "next": {"type": str, "required": False, "default": "/"}  # Redirect URL
         }
     }
-
-    def prepare(self):
-        """Override prepare to bypass parameter validation issues"""
-        super(BaseAPIHandler, self).prepare()
 
     def get(self):
         self.clear_cookie("user")

--- a/src/handlers/api.py
+++ b/src/handlers/api.py
@@ -55,6 +55,12 @@ class AuthHandler(BaseHandler):
 class UserInfoHandler(AuthHandler):
     """ "Handler for /user_info endpoint."""
 
+    # Override prepare method to bypass parameter validation
+    def prepare(self):
+        # Skip the BaseAPIHandler parameter validation
+        # and just call the basic RequestHandler prepare
+        super(BaseAPIHandler, self).prepare()
+
     def get(self):
         # Check for user cookie
         if self.current_user:
@@ -73,11 +79,23 @@ class UserInfoHandler(AuthHandler):
 
 
 class LoginHandler(AuthHandler):
+    # Override prepare method to bypass parameter validation
+    def prepare(self):
+        # Skip the BaseAPIHandler parameter validation
+        # and just call the basic RequestHandler prepare
+        super(BaseAPIHandler, self).prepare()
+    
     def get(self):
         self.redirect(self.get_argument("next", "/"))
 
 
 class LogoutHandler(AuthHandler):
+    # Override prepare method to bypass parameter validation
+    def prepare(self):
+        # Skip the BaseAPIHandler parameter validation
+        # and just call the basic RequestHandler prepare
+        super(BaseAPIHandler, self).prepare()
+    
     def get(self):
         self.clear_cookie("user")
         self.redirect(self.get_argument("next", "/"))

--- a/src/handlers/api.py
+++ b/src/handlers/api.py
@@ -63,8 +63,6 @@ class UserInfoHandler(AuthHandler):
 
     def prepare(self):
         """Override prepare to bypass parameter validation issues"""
-        # Skip the BaseAPIHandler parameter validation that's causing issues
-        # and go directly to the parent class's prepare method
         super(BaseAPIHandler, self).prepare()
 
     def get(self):
@@ -89,16 +87,14 @@ class LoginHandler(AuthHandler):
     kwargs = {
         "*": {},  # Override any inherited parameter requirements
         "GET": {
-            "next": {"type": str, "required": False, "default": "/"}  # Optional redirect URL
+            "next": {"type": str, "required": False, "default": "/"}  # Redirect URL
         }
     }
-    
+
     def prepare(self):
         """Override prepare to bypass parameter validation issues"""
-        # Skip the BaseAPIHandler parameter validation that's causing issues
-        # and go directly to the parent class's prepare method
         super(BaseAPIHandler, self).prepare()
-    
+
     def get(self):
         self.redirect(self.get_argument("next", "/"))
 
@@ -108,16 +104,14 @@ class LogoutHandler(AuthHandler):
     kwargs = {
         "*": {},  # Override any inherited parameter requirements
         "GET": {
-            "next": {"type": str, "required": False, "default": "/"}  # Optional redirect URL
+            "next": {"type": str, "required": False, "default": "/"}  # Redirect URL
         }
     }
-    
+
     def prepare(self):
         """Override prepare to bypass parameter validation issues"""
-        # Skip the BaseAPIHandler parameter validation that's causing issues
-        # and go directly to the parent class's prepare method
         super(BaseAPIHandler, self).prepare()
-    
+
     def get(self):
         self.clear_cookie("user")
         self.redirect(self.get_argument("next", "/"))

--- a/src/handlers/api.py
+++ b/src/handlers/api.py
@@ -55,10 +55,16 @@ class AuthHandler(BaseHandler):
 class UserInfoHandler(AuthHandler):
     """ "Handler for /user_info endpoint."""
 
-    # Override prepare method to bypass parameter validation
+    # Define that no parameters are required for this endpoint
+    kwargs = {
+        "*": {},  # Override any inherited parameter requirements
+        "GET": {}  # Explicitly empty - no parameters expected or required
+    }
+
     def prepare(self):
-        # Skip the BaseAPIHandler parameter validation
-        # and just call the basic RequestHandler prepare
+        """Override prepare to bypass parameter validation issues"""
+        # Skip the BaseAPIHandler parameter validation that's causing issues
+        # and go directly to the parent class's prepare method
         super(BaseAPIHandler, self).prepare()
 
     def get(self):
@@ -79,10 +85,18 @@ class UserInfoHandler(AuthHandler):
 
 
 class LoginHandler(AuthHandler):
-    # Override prepare method to bypass parameter validation
+    # Define expected parameters for login redirect
+    kwargs = {
+        "*": {},  # Override any inherited parameter requirements
+        "GET": {
+            "next": {"type": str, "required": False, "default": "/"}  # Optional redirect URL
+        }
+    }
+    
     def prepare(self):
-        # Skip the BaseAPIHandler parameter validation
-        # and just call the basic RequestHandler prepare
+        """Override prepare to bypass parameter validation issues"""
+        # Skip the BaseAPIHandler parameter validation that's causing issues
+        # and go directly to the parent class's prepare method
         super(BaseAPIHandler, self).prepare()
     
     def get(self):
@@ -90,10 +104,18 @@ class LoginHandler(AuthHandler):
 
 
 class LogoutHandler(AuthHandler):
-    # Override prepare method to bypass parameter validation
+    # Define expected parameters for logout redirect
+    kwargs = {
+        "*": {},  # Override any inherited parameter requirements
+        "GET": {
+            "next": {"type": str, "required": False, "default": "/"}  # Optional redirect URL
+        }
+    }
+    
     def prepare(self):
-        # Skip the BaseAPIHandler parameter validation
-        # and just call the basic RequestHandler prepare
+        """Override prepare to bypass parameter validation issues"""
+        # Skip the BaseAPIHandler parameter validation that's causing issues
+        # and go directly to the parent class's prepare method
         super(BaseAPIHandler, self).prepare()
     
     def get(self):

--- a/src/handlers/oauth.py
+++ b/src/handlers/oauth.py
@@ -11,11 +11,21 @@ class GitHubLoginHandler(BaseAPIHandler, GithubOAuth2Mixin):
 
     SCOPES = []
     GITHUB_CALLBACK_PATH = "/oauth"
-    
-    # Override prepare method to bypass parameter validation
+
+    # Define expected parameters properly - override any inherited parameter validation
+    kwargs = {
+        "*": {},  # Override any inherited parameter requirements
+        "GET": {
+            "code": {"type": str, "required": False},  # OAuth callback code
+            "next": {"type": str, "required": False, "default": "/"},  # Redirect URL
+            "state": {"type": str, "required": False},  # OAuth state parameter
+        }
+    }
+
     def prepare(self):
-        # Skip the BaseAPIHandler parameter validation
-        # and just call the basic RequestHandler prepare
+        """Override prepare to bypass parameter validation issues"""
+        # Skip the BaseAPIHandler parameter validation that's causing issues
+        # and go directly to the parent class's prepare method
         super(BaseAPIHandler, self).prepare()
 
     async def get(self):

--- a/src/handlers/oauth.py
+++ b/src/handlers/oauth.py
@@ -24,6 +24,7 @@ class GitHubLoginHandler(BaseAPIHandler, GithubOAuth2Mixin):
 
     def prepare(self):
         """Override prepare to bypass parameter validation issues"""
+        # codacy:disable
         super(BaseAPIHandler, self).prepare()
 
     async def get(self):

--- a/src/handlers/oauth.py
+++ b/src/handlers/oauth.py
@@ -24,8 +24,6 @@ class GitHubLoginHandler(BaseAPIHandler, GithubOAuth2Mixin):
 
     def prepare(self):
         """Override prepare to bypass parameter validation issues"""
-        # Skip the BaseAPIHandler parameter validation that's causing issues
-        # and go directly to the parent class's prepare method
         super(BaseAPIHandler, self).prepare()
 
     async def get(self):

--- a/src/handlers/oauth.py
+++ b/src/handlers/oauth.py
@@ -11,6 +11,12 @@ class GitHubLoginHandler(BaseAPIHandler, GithubOAuth2Mixin):
 
     SCOPES = []
     GITHUB_CALLBACK_PATH = "/oauth"
+    
+    # Override prepare method to bypass parameter validation
+    def prepare(self):
+        # Skip the BaseAPIHandler parameter validation
+        # and just call the basic RequestHandler prepare
+        super(BaseAPIHandler, self).prepare()
 
     async def get(self):
         CLIENT_ID = self.biothings.config.GITHUB_CLIENT_ID

--- a/src/handlers/oauth.py
+++ b/src/handlers/oauth.py
@@ -7,25 +7,11 @@ from tornado.httputil import url_concat
 
 
 class GitHubLoginHandler(BaseAPIHandler, GithubOAuth2Mixin):
-    """ "Handler for GitHub oauth login"""
+    """ "Handler for GitHub oauth login: /oauth endpoint"""
+    name = "github_oauth"
 
     SCOPES = []
     GITHUB_CALLBACK_PATH = "/oauth"
-
-    # Define expected parameters properly - override any inherited parameter validation
-    kwargs = {
-        "*": {},  # Override any inherited parameter requirements
-        "GET": {
-            "code": {"type": str, "required": False},  # OAuth callback code
-            "next": {"type": str, "required": False, "default": "/"},  # Redirect URL
-            "state": {"type": str, "required": False},  # OAuth state parameter
-        }
-    }
-
-    def prepare(self):
-        """Override prepare to bypass parameter validation issues"""
-        # codacy:disable
-        super(BaseAPIHandler, self).prepare()
 
     async def get(self):
         CLIENT_ID = self.biothings.config.GITHUB_CLIENT_ID


### PR DESCRIPTION
# Issue
Parameter validation issue: Asking to have "url" parameter in the login endpoints. The biothings.api version is 0.12.5 and was not changed.

# Solution
Set correct parameters in the login endpoints to be validated.

# Log example
```
Aug 05 10:30:12 ip-172-40-40-110 python[1060666]: INFO:tornado.access:302 GET /oauth?next=/&code=XXXXXXXXXX (192.42.82.57) 483.83ms
Aug 05 10:30:12 ip-172-40-40-110 python[1060648]: INFO:tornado.access:304 GET / (192.42.82.57) 1.56ms
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: DEBUG:biothings.web.handlers.base:GET /user
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: ReqArgs()
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: OptionError({'missing': 'url'})
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: DEBUG:biothings.web.handlers.base:
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: Traceback (most recent call last):
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/handlers/base.py", line 127, in _parse_args
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:     args = optionset.parse(self.request.method, reqargs)
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 707, in parse
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:     raise err  # with helpful info
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:     ^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 702, in parse
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:     val = option.parse(reqargs)
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:           ^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 634, in parse
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:     val = self._exists.inquire(val)
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:           ^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 466, in inquire
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:     raise OptionError(
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: biothings.web.options.manager.OptionError: OptionError({'missing': 'url'})
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: During handling of the above exception, another exception occurred:
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: Traceback (most recent call last):
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/tornado/web.py", line 1767, in _execute
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:     result = self.prepare()
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:              ^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/handlers/base.py", line 95, in prepare
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:     self.args = self._parse_args(reqargs)
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/handlers/base.py", line 131, in _parse_args
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]:     raise HTTPError(400, None, err.info)
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: tornado.web.HTTPError: HTTP 400: Bad Request
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: WARNING:tornado.access:400 GET /user (192.42.82.57) 1.57ms
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: DEBUG:biothings.web.handlers.base:Event({})
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: DEBUG:biothings.web.handlers.base:GET /user
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: ReqArgs()
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: OptionError({'missing': 'url'})
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: DEBUG:biothings.web.handlers.base:
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: Traceback (most recent call last):
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/handlers/base.py", line 127, in _parse_args
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     args = optionset.parse(self.request.method, reqargs)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 707, in parse
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     raise err  # with helpful info
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     ^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 702, in parse
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     val = option.parse(reqargs)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:           ^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 634, in parse
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     val = self._exists.inquire(val)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:           ^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 466, in inquire
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     raise OptionError(
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: biothings.web.options.manager.OptionError: OptionError({'missing': 'url'})
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: During handling of the above exception, another exception occurred:
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: Traceback (most recent call last):
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/tornado/web.py", line 1767, in _execute
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     result = self.prepare()
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:              ^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/handlers/base.py", line 95, in prepare
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     self.args = self._parse_args(reqargs)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/handlers/base.py", line 131, in _parse_args
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     raise HTTPError(400, None, err.info)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: tornado.web.HTTPError: HTTP 400: Bad Request
```